### PR TITLE
Export interfaces, types and Isapi class.

### DIFF
--- a/src/ISAPI.ts
+++ b/src/ISAPI.ts
@@ -26,20 +26,20 @@ import {
   userCheck,
 } from '@types';
 
-interface ISAPIConfig {
+export interface ISAPIConfig {
   host: string;
   port: string | number;
   username: string;
   password: string;
 }
 
-interface ExtraParams {
+export interface ExtraParams {
   convert?: boolean;
   config?: AxiosRequestConfig;
   headers?: RawAxiosRequestHeaders;
 }
 
-interface ISAPI {
+export interface ISAPI {
   get: <T>(url: string, args?: ExtraParams) => Promise<T>;
   post: <T>(
     url: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,6 @@
-export { default } from './ISAPI';
+import { default as Isapi } from './ISAPI';
+
+export * from './ISAPI';
+export * from './types';
+
+export default Isapi;


### PR DESCRIPTION
This commit fixes a bug: Cannot import default class, interfaces, and types.